### PR TITLE
fix: remove expires field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,18 @@ go 1.23
 toolchain go1.23.2
 
 require (
+	github.com/ipfs/go-cid v0.4.1
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/storacha/go-ucanto v0.1.1-0.20241018155815-175193fb3b33
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -24,7 +27,6 @@ require (
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-blockservice v0.5.2 // indirect
-	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.3.1 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.1 // indirect
@@ -63,6 +65,7 @@ require (
 	github.com/pion/stun v0.6.1 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.0 // indirect
@@ -83,5 +86,6 @@ require (
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 )

--- a/pkg/blob/accept_test.go
+++ b/pkg/blob/accept_test.go
@@ -1,0 +1,32 @@
+package blob
+
+import (
+	"testing"
+
+	"github.com/storacha/go-capabilities/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripAcceptCaveats(t *testing.T) {
+	digest, bytes := testutil.RandomBytes(t, 256)
+	nb := AcceptCaveats{
+		Space: testutil.RandomPrincipal(t).DID(),
+		Blob: Blob{
+			Digest: digest,
+			Size:   uint64(len(bytes)),
+		},
+		Put: Promise{
+			UcanAwait: Await{
+				Selector: ".out.ok",
+				Link:     testutil.RandomCID(t),
+			},
+		},
+	}
+
+	node, err := nb.ToIPLD()
+	require.NoError(t, err)
+
+	rnb, err := AcceptCaveatsReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, nb, rnb)
+}

--- a/pkg/blob/allocate.go
+++ b/pkg/blob/allocate.go
@@ -88,28 +88,25 @@ func (ao AllocateOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(md, bdm.AllocateOkType())
 }
 
-var Allocate = validator.NewCapability(
-	AllocateAbility,
-	schema.DIDString(),
-	schema.Mapped(schema.Struct[bdm.AllocateCaveatsModel](bdm.AllocateCaveatsType(), nil), func(model bdm.AllocateCaveatsModel) (AllocateCaveats, failure.Failure) {
-		space, err := did.Decode(model.Space)
-		if err != nil {
-			return AllocateCaveats{}, failure.FromError(fmt.Errorf("decoding space DID: %w", err))
-		}
+var AllocateCaveatsReader = schema.Mapped(schema.Struct[bdm.AllocateCaveatsModel](bdm.AllocateCaveatsType(), nil), func(model bdm.AllocateCaveatsModel) (AllocateCaveats, failure.Failure) {
+	space, err := did.Decode(model.Space)
+	if err != nil {
+		return AllocateCaveats{}, failure.FromError(fmt.Errorf("decoding space DID: %w", err))
+	}
 
-		digest, err := multihash.Cast(model.Blob.Digest)
-		if err != nil {
-			return AllocateCaveats{}, failure.FromError(fmt.Errorf("decoding digest: %w", err))
-		}
+	digest, err := multihash.Cast(model.Blob.Digest)
+	if err != nil {
+		return AllocateCaveats{}, failure.FromError(fmt.Errorf("decoding digest: %w", err))
+	}
 
-		return AllocateCaveats{
-			Space: space,
-			Blob: Blob{
-				Digest: digest,
-				Size:   uint64(model.Blob.Size),
-			},
-			Cause: model.Cause,
-		}, nil
-	}),
-	validator.DefaultDerives,
-)
+	return AllocateCaveats{
+		Space: space,
+		Blob: Blob{
+			Digest: digest,
+			Size:   uint64(model.Blob.Size),
+		},
+		Cause: model.Cause,
+	}, nil
+})
+
+var Allocate = validator.NewCapability(AllocateAbility, schema.DIDString(), AllocateCaveatsReader, validator.DefaultDerives)

--- a/pkg/blob/allocate_test.go
+++ b/pkg/blob/allocate_test.go
@@ -1,0 +1,27 @@
+package blob
+
+import (
+	"testing"
+
+	"github.com/storacha/go-capabilities/pkg/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripAllocateCaveats(t *testing.T) {
+	digest, bytes := testutil.RandomBytes(t, 256)
+	nb := AllocateCaveats{
+		Space: testutil.RandomPrincipal(t).DID(),
+		Blob: Blob{
+			Digest: digest,
+			Size:   uint64(len(bytes)),
+		},
+		Cause: testutil.RandomCID(t),
+	}
+
+	node, err := nb.ToIPLD()
+	require.NoError(t, err)
+
+	rnb, err := AllocateCaveatsReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, nb, rnb)
+}

--- a/pkg/blob/datamodel/blob.go
+++ b/pkg/blob/datamodel/blob.go
@@ -74,10 +74,9 @@ type PromiseModel struct {
 }
 
 type AcceptCaveatsModel struct {
-	Space   []byte
-	Blob    BlobModel
-	Expires int64
-	Put     PromiseModel
+	Space []byte
+	Blob  BlobModel
+	Put   PromiseModel
 }
 
 type AcceptOkModel struct {

--- a/pkg/blob/datamodel/blob.ipldsch
+++ b/pkg/blob/datamodel/blob.ipldsch
@@ -34,7 +34,6 @@ type Promise struct {
 type AcceptCaveats struct {
   space DID
   blob Blob
-  expires Int
   put Promise (rename "_put")
 }
 

--- a/pkg/internal/testutil/gen.go
+++ b/pkg/internal/testutil/gen.go
@@ -1,0 +1,39 @@
+package testutil
+
+import (
+	crand "crypto/rand"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func RandomCID(t *testing.T) ipld.Link {
+	digest, _ := RandomBytes(t, 10)
+	return cidlink.Link{Cid: cid.NewCidV1(cid.Raw, digest)}
+}
+
+func RandomBytes(t *testing.T, size int) (multihash.Multihash, []byte) {
+	bytes := make([]byte, size)
+	_, err := crand.Read(bytes)
+	require.NoError(t, err)
+	digest, err := multihash.Sum(bytes, multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	return digest, bytes
+}
+
+func RandomPrincipal(t *testing.T) ucan.Principal {
+	return RandomSigner(t)
+}
+
+func RandomSigner(t *testing.T) principal.Signer {
+	id, err := signer.Generate()
+	require.NoError(t, err)
+	return id
+}


### PR DESCRIPTION
This seems to be not spec'd...there's a `ttl` field in w3up but it is optional and unused. Hence I've just remove it from here for now.

PR also exposes the caveat readers and adds 2 round trip tests.