### PR TITLE
fix(assert): fix casing on other caveats schema types

### DIFF
--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -76,9 +76,12 @@ type LegacyLocationCaveats struct {
 }
 
 func (lc LocationCaveats) ToIPLD() (datamodel.Node, error) {
-
+	space := &lc.Space
+	if lc.Space == did.Undef {
+		space = nil
+	}
 	return ipld.WrapWithRecovery(&LegacyLocationCaveats{
-		lc.Content, lc.Location, lc.Range, &lc.Space,
+		lc.Content, lc.Location, lc.Range, space,
 	}, LocationCaveatsType(), types.Converters...)
 }
 

--- a/pkg/assert/assert.ipldsch
+++ b/pkg/assert/assert.ipldsch
@@ -38,17 +38,17 @@ type RelationPartInclusion struct {
 }
 
 type RelationPart struct {
-	Content  V1Link
-	Includes optional RelationPartInclusion
+	content  V1Link
+	includes optional RelationPartInclusion
 }
 
 type RelationCaveats struct {
-	Content  HasMultihash
-	Children [Link]
-	Parts    [RelationPart]
+	content  HasMultihash
+	children [Link]
+	parts    [RelationPart]
 }
 
 type EqualsCaveats struct {
-	Content HasMultihash
-	Equals Link
+	content HasMultihash
+	equals Link
 }

--- a/pkg/types/converters.go
+++ b/pkg/types/converters.go
@@ -33,7 +33,12 @@ var HasMultihashConverter = options.NamedAnyConverter("HasMultihash", func(nd da
 	return h.ToIPLD()
 })
 
-var DIDConverter = options.NamedBytesConverter("DID", did.Decode, func(did did.DID) ([]byte, error) { return did.Bytes(), nil })
+var DIDConverter = options.NamedBytesConverter("DID", func(bytes []byte) (did.DID, error) {
+	if len(bytes) == 0 {
+		return did.Undef, nil
+	}
+	return did.Decode(bytes)
+}, func(did did.DID) ([]byte, error) { return did.Bytes(), nil })
 
 var URLConverter = options.NamedStringConverter("URL",
 	func(s string) (url.URL, error) { return schema.URI().Read(s) },


### PR DESCRIPTION
# Goals

I noticed issues synthesizing equals claims in the indexer, because equals never got its schema lowercased

# Implementation

use lowercase for members of relation and equals caveats